### PR TITLE
dgraphコンテナを起動するためのdocker-compose.yml作成

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,15 @@
+docker-composeコマンド
+
+* dockerを起動する。
+
+ローカル開発環境(コンテナをバックグラウンドで実行する場合はupの後に-dもしくは--detachをつける)
+```bash
+docker-compose -f docker-compose.yml -f local.yml up
+```
+
+* dockerをダウンする。(コンテナをバックグラウンド実行した場合)
+
+ローカル開発環境
+```bash
+docker-compose -f docker-compose.yml -f local.yml down
+```

--- a/infra/README.md
+++ b/infra/README.md
@@ -4,12 +4,12 @@ docker-composeコマンド
 
 ローカル開発環境(コンテナをバックグラウンドで実行する場合はupの後に-dもしくは--detachをつける)
 ```bash
-docker-compose -f docker-compose.yml -f local.yml up
+docker compose -f docker-compose.yml -f local.yml up
 ```
 
 * dockerをダウンする。(コンテナをバックグラウンド実行した場合)
 
 ローカル開発環境
 ```bash
-docker-compose -f docker-compose.yml -f local.yml down
+docker compose -f docker-compose.yml -f local.yml down
 ```

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,30 @@
+# This Docker Compose file can be used to quickly bootup Dgraph Zero
+# and Alpha in different Docker containers.
+
+# It mounts /tmp/data on the host machine to /dgraph within the
+# container. You can change /tmp/data to a more appropriate location.
+# Run `docker-compose up` to start Dgraph.
+# NOTE: whitelisting is set to private address ranges, this is ONLY for a local setup
+#       please change it accordingly for your production setup
+#       more here https://dgraph.io/docs/deploy/dgraph-administration/#whitelisting-admin-operations
+
+version: "3.2"
+services:
+  zero:
+    image: dgraph/dgraph:latest
+    volumes:
+      - /tmp/data:/dgraph
+    ports:
+      - 5080:5080
+      - 6080:6080
+    restart: on-failure
+    command: dgraph zero --my=zero:5080
+  alpha:
+    image: dgraph/dgraph:latest
+    volumes:
+      - /tmp/data:/dgraph
+    ports:
+      - 8080:8080
+      - 9080:9080
+    restart: on-failure
+    command: dgraph alpha --my=alpha:7080 --zero=zero:5080 --security whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -8,7 +8,7 @@
 #       please change it accordingly for your production setup
 #       more here https://dgraph.io/docs/deploy/dgraph-administration/#whitelisting-admin-operations
 
-version: "3.2"
+version: "3.8"
 services:
   zero:
     image: dgraph/dgraph:latest

--- a/infra/local.yml
+++ b/infra/local.yml
@@ -1,0 +1,4 @@
+version: "3.2"
+services:
+  alpha:
+    command: dgraph alpha --my=alpha:7080 --zero=zero:5080 --security whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1


### PR DESCRIPTION
追加点

1. dgraphコンテナを起動するためのdocker-compose.yml作成。
2. ローカル環境向けに起動するためにlocal.ymlを追加。
3. ローカル開発環境向けのdockerコンテナを操作するためのコマンドを記述したREADME.md作成

docker-compose.ymlでalphaコンテナとzeroコンテナを作成しているのは、Dgraphが少なくともalphaノードとzeroノードを各１つずつ必要とするため。alphaノードとzeroノードについての簡単な説明は下記に記述する。

Dgraphはクラスターを構成し、クラスターは複数のalphaノードまたはzeroノードを含めることができる。(最小構成はalphaノード1, zeroノード1)
各alphaノード, zeroノードはそれぞれalphaグループ、zeroグループに属する。(グループは複数作成することもできる)
alphaグループはデータのホストを行い、同じグループに属するalphaノード間でデータをレプリケートする。
zeroノードはalphaグループ間のデータバランス監視し、バランスに偏りがある場合データをディスク使用率の低いグループに移動したりする。
参照: https://dgraph.io/blog/post/db-sharding/
