### PR TITLE
chore: docker-compose.ymlのversionが非推奨になったため削除   TIHU-26

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -8,7 +8,6 @@
 #       please change it accordingly for your production setup
 #       more here https://dgraph.io/docs/deploy/dgraph-administration/#whitelisting-admin-operations
 
-version: "3.8"
 services:
   zero:
     image: dgraph/dgraph:latest

--- a/infra/local.yml
+++ b/infra/local.yml
@@ -1,4 +1,3 @@
-version: "3.2"
 services:
   alpha:
     command: dgraph alpha --my=alpha:7080 --zero=zero:5080 --security whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1


### PR DESCRIPTION
変更点
docker-compose.ymlのversion指定が非推奨になっていたので削除した。
https://docs.docker.com/compose/compose-file/
https://docs.docker.com/compose/compose-file/#version-top-level-element

version指定の削除後の動作確認はget-startedのコマンドを実行して確認した。
https://dgraph.io/docs/get-started/