### PR TITLE
カード名での部分一致検索ができるように、カード検索クエリの仕様を変更

### DIFF
--- a/libs/db-manipulation/index.mjs
+++ b/libs/db-manipulation/index.mjs
@@ -45,7 +45,8 @@ mutation addTwoCard($input: [AddMtgCardInput!]!) {
   const addTwoCardsVariables = {
     input: [
       {
-        nameEn: "Test Card Name",
+        nameEn: "Test Card Names",
+        nameJa: "闇の剣士が走る",
         imageUrlEn:
           "https://cards.scryfall.io/small/front/1/f/1f0d2e8e-c8f2-4b31-a6ba-6283fc8740d4.jpg?1562433485",
         colors: ["WHITE"],
@@ -54,7 +55,8 @@ mutation addTwoCard($input: [AddMtgCardInput!]!) {
         collectorNumber: "1/001",
       },
       {
-        nameEn: "Test Card Name2",
+        nameEn: "Test Card Naming",
+        nameJa: "闇の戦士が走った",
         imageUrlEn:
           "https://cards.scryfall.io/small/front/9/e/9ea8179a-d3c9-4cdc-a5b5-68cc73279050.jpg?1562433485",
         colors: ["WHITE"],
@@ -111,5 +113,5 @@ const addSynergy = async (ids) => {
 
 const responseData = await addTwoCards();
 
-const cardIds = responseData.data.addMtgCard.mtgCard.map((card) => card.ID);
-addSynergy(cardIds);
+// const cardIds = responseData.data.addMtgCard.mtgCard.map((card) => card.ID);
+// addSynergy(cardIds);

--- a/libs/db-manipulation/schema.graphql
+++ b/libs/db-manipulation/schema.graphql
@@ -15,8 +15,8 @@ enum Rarity {
 
 type MtgCard {
     id: ID!
-    nameJa: String
-    nameEn: String!
+    nameJa: String @search(by: [regexp])
+    nameEn: String! @search(by: [regexp])
     imageUrlJa: String
     imageUrlEn: String!
     colors: [Color]!


### PR DESCRIPTION
### 1. クエリの仕様を変更しました

`queryMtgCard`クエリにて、カード名の部分一致検索を可能にしました。

### 2. サンプルデータの内容を変更しました

表題と直接関係ありませんが、サンプルデータを一部変更しました。本来は語幹での検索機能(活用が変わってもまとめて検索可能)の動作確認のための変更でした。こちらの機能は不採用となったのですが、サンプルデータに日本語カード名が入っているほうが今後なにかと有用と思いコミットします。