### PR TITLE
カード検索機能 リゾルバを追加

### DIFF
--- a/apps/backend/codegen.yml
+++ b/apps/backend/codegen.yml
@@ -1,6 +1,8 @@
 # codegen.yml
 overwrite: true
-schema: "./schemas/dgraph-schema.graphql" # schema.graphqlがあるディレクトリ
+schema:
+  - "./schemas/dgraph-schema.graphql" # schema.graphqlがあるディレクトリ
+  - "./schemas/custom.graphql" # schema.graphqlがあるディレクトリ
 generates:
   src/generated/types.ts: # 型定義ファイルを保存するディレクトリ
     plugins:

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -15,8 +15,9 @@
         "@graphql-codegen/typescript-resolvers": "^3.1.1",
         "@graphql-tools/load-files": "^6.6.1",
         "@graphql-tools/merge": "^8.4.0",
-        "@matzryo/synergy-map-libraries": "^0.0.1",
-        "graphql": "^16.6.0"
+        "@matzryo/synergy-map-libraries": "^0.0.2",
+        "graphql": "^16.6.0",
+        "graphql-tag": "^2.12.6"
       },
       "devDependencies": {
         "@types/node": "^18.11.18",
@@ -26,7 +27,7 @@
       },
       "engines": {
         "node": ">=18.12.1 <19.0.0",
-        "npm": ">=8.19.2 <9.0.0"
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1903,9 +1904,9 @@
       }
     },
     "node_modules/@matzryo/synergy-map-libraries": {
-      "version": "0.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@matzryo/synergy-map-libraries/0.0.1/6cce96c8732fee9b685a5cd2062aeaa3d7186e4a",
-      "integrity": "sha512-zrgZaamDnB0BjUE3qPbZZ+6SD3XUNq9CXwO5jFJxitN/63+5tMCYUojEpaC2KkZGArMU1W4X+JAV72vimMguqQ==",
+      "version": "0.0.2",
+      "resolved": "https://npm.pkg.github.com/download/@matzryo/synergy-map-libraries/0.0.2/39424e20853a0c5fd6c43dc15b827159519d5a5f",
+      "integrity": "sha512-wXA0OQao8Ux1DVsRCgIVJI82m0F6Ej63SfnXCL9v9Mq9kd1OEQx3VR9uwVn3UyGAUghjM8LfzocTDYcNP8xEJg==",
       "license": "ISC"
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7240,9 +7241,9 @@
       }
     },
     "@matzryo/synergy-map-libraries": {
-      "version": "0.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@matzryo/synergy-map-libraries/0.0.1/6cce96c8732fee9b685a5cd2062aeaa3d7186e4a",
-      "integrity": "sha512-zrgZaamDnB0BjUE3qPbZZ+6SD3XUNq9CXwO5jFJxitN/63+5tMCYUojEpaC2KkZGArMU1W4X+JAV72vimMguqQ=="
+      "version": "0.0.2",
+      "resolved": "https://npm.pkg.github.com/download/@matzryo/synergy-map-libraries/0.0.2/39424e20853a0c5fd6c43dc15b827159519d5a5f",
+      "integrity": "sha512-wXA0OQao8Ux1DVsRCgIVJI82m0F6Ej63SfnXCL9v9Mq9kd1OEQx3VR9uwVn3UyGAUghjM8LfzocTDYcNP8xEJg=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,8 +20,9 @@
     "@graphql-codegen/typescript-resolvers": "^3.1.1",
     "@graphql-tools/load-files": "^6.6.1",
     "@graphql-tools/merge": "^8.4.0",
-    "@matzryo/synergy-map-libraries": "^0.0.1",
-    "graphql": "^16.6.0"
+    "@matzryo/synergy-map-libraries": "^0.0.2",
+    "graphql": "^16.6.0",
+    "graphql-tag": "^2.12.6"
   },
   "devDependencies": {
     "@types/node": "^18.11.18",

--- a/apps/backend/schemas/custom.graphql
+++ b/apps/backend/schemas/custom.graphql
@@ -1,0 +1,3 @@
+type Query {
+  SearchMtgCard(searchString: String!): [MtgCard]!
+}

--- a/apps/backend/src/generated/types.ts
+++ b/apps/backend/src/generated/types.ts
@@ -427,12 +427,18 @@ export type PolygonRef = {
 
 export type Query = {
   __typename?: 'Query';
+  SearchMtgCard: Array<Maybe<MtgCard>>;
   aggregateMtgCard?: Maybe<MtgCardAggregateResult>;
   aggregateSynergy?: Maybe<SynergyAggregateResult>;
   getMtgCard?: Maybe<MtgCard>;
   getSynergy?: Maybe<Synergy>;
   queryMtgCard?: Maybe<Array<Maybe<MtgCard>>>;
   querySynergy?: Maybe<Array<Maybe<Synergy>>>;
+};
+
+
+export type QuerySearchMtgCardArgs = {
+  searchString: Scalars['String'];
 };
 
 
@@ -1033,6 +1039,7 @@ export type PolygonResolvers<ContextType = any, ParentType extends ResolversPare
 };
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+  SearchMtgCard?: Resolver<Array<Maybe<ResolversTypes['MtgCard']>>, ParentType, ContextType, RequireFields<QuerySearchMtgCardArgs, 'searchString'>>;
   aggregateMtgCard?: Resolver<Maybe<ResolversTypes['MtgCardAggregateResult']>, ParentType, ContextType, Partial<QueryAggregateMtgCardArgs>>;
   aggregateSynergy?: Resolver<Maybe<ResolversTypes['SynergyAggregateResult']>, ParentType, ContextType, Partial<QueryAggregateSynergyArgs>>;
   getMtgCard?: Resolver<Maybe<ResolversTypes['MtgCard']>, ParentType, ContextType, RequireFields<QueryGetMtgCardArgs, 'id'>>;

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -20,7 +20,7 @@ services:
   zero:
     image: dgraph/dgraph:latest
     volumes:
-      - /tmp/data:/dgraph
+      - dgraph-zero-data:/dgraph
     ports:
       - 5080:5080
       - 6080:6080
@@ -29,9 +29,12 @@ services:
   alpha:
     image: dgraph/dgraph:latest
     volumes:
-      - /tmp/data:/dgraph
+      - dgraph-alpha-data:/dgraph
     ports:
       - 8080:8080
       - 9080:9080
     restart: on-failure
     command: dgraph alpha --my=alpha:7080 --zero=zero:5080 --security whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1
+volumes:
+  dgraph-alpha-data:
+  dgraph-zero-data:

--- a/libs/backend-manipulation/fetch-dgraph-schema.mjs
+++ b/libs/backend-manipulation/fetch-dgraph-schema.mjs
@@ -1,4 +1,4 @@
-import { request } from "../requests/query-to-dgraph-graphql-api.js";
+import { request } from "../requests/index.js";
 import { writeFileSync } from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";

--- a/libs/db-manipulation/post-sample-data.mjs
+++ b/libs/db-manipulation/post-sample-data.mjs
@@ -1,4 +1,4 @@
-import { request } from "../requests/query-to-dgraph-graphql-api.js"
+import { request } from "../requests/index.js"
 
 /**
  * カード二枚(テストデータ)を投入する

--- a/libs/requests/index.d.ts
+++ b/libs/requests/index.d.ts
@@ -1,2 +1,7 @@
 import { Response } from 'node-fetch';
-export function request(query: string, variables: Object, graphqlApiUrl: string): Promise<Response>;
+type RequestOpts = {
+    query: string,
+    variables?: Record<string, any>,
+    graphqlApiUrl?: string
+}
+export function request({query, variables, graphqlApiUrl}: RequestOpts): Promise<Response>;

--- a/libs/requests/package.json
+++ b/libs/requests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matzryo/synergy-map-libraries",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "description": "utilities for our apps.",
   "main": "index.js",


### PR DESCRIPTION
Apollo Serverに、カード検索クエリ(searchMtgCard)を追加しました。

その他、バグ修正も行いました。横着して本PRに含めちゃいます。詳細は以下のとおりです。
1. 独自npmライブラリsynergy-map-librariesの型定義が実装と食い違っていたのを修正
1. Dgraphのデータ永続化が不完全だったのを修正